### PR TITLE
Update documentation, calibration is not automatically run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ Calibration is essential for accurate position tracking. The integration measure
 #### Starting Calibration
 
 You can calibrate a blind:
-- **During initial pairing**: After naming your device, you'll be prompted to calibrate
-- **Later from the device page**: Go to the device and click the **Calibrate** gear icon (⚙️) as shown below
+- **After pairing from the device page**: Go to the device and click the **Calibrate** gear icon (⚙️) as shown below
 
 ![Calibrate button location](images/calibrate-button.png)
 


### PR DESCRIPTION
Remove the false documentation that says calibration is automatically run after pairing. It might not be possible to auto run the calibration because home assistant does not add the entity until the integration is reloaded which breaks any configuration flow.