### PR TITLE
Fix pairing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Calibration is essential for accurate position tracking. The integration measure
 #### Starting Calibration
 
 You can calibrate a blind:
+- **During initial pairing**: After naming your device, you'll be prompted to calibrate
 - **After pairing from the device page**: Go to the device and click the **Calibrate** gear icon (⚙️) as shown below
 
 ![Calibrate button location](images/calibrate-button.png)


### PR DESCRIPTION
At some point the pairing command got messed up and I did not notice because my test device was already paired.